### PR TITLE
Update code to work with nightly 2016-06-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ An experimental compiler from [Rust] to [WebAssembly], based on rustc + Rust [MI
 I recommend that you install [rustup] and then use it to
 install the current rustc nightly version:
 
+**Tested with nightly 2016-06-04**
+
 ```sh
 git clone https://github.com/brson/mir2wasm.git
 cd mir2wasm

--- a/src/bin/mir2wasm.rs
+++ b/src/bin/mir2wasm.rs
@@ -28,7 +28,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
         control.after_analysis.stop = rustc_driver::Compilation::Stop;
         control.after_analysis.callback = Box::new(|state| {
             state.session.abort_if_errors();
-            trans::trans_crate(state.tcx.unwrap(), state.mir_map.unwrap())
+            trans::trans_crate(&state.tcx.unwrap(), state.mir_map.unwrap())
                 .unwrap(); // FIXME
         });
 

--- a/src/monomorphize.rs
+++ b/src/monomorphize.rs
@@ -1,13 +1,13 @@
 use rustc::ty::subst::{Subst, Substs};
 use rustc::ty::{TyCtxt, TypeFoldable};
-use rustc::infer::normalize_associated_type;
+use rustc::infer::TransNormalize;
 
-pub fn apply_param_substs<'tcx,T>(tcx: &TyCtxt<'tcx>,
+pub fn apply_param_substs<'a, 'tcx,T>(tcx: &TyCtxt<'a, 'tcx, 'tcx>,
                                   param_substs: &Substs<'tcx>,
                                   value: &T)
                                   -> T
-    where T : TypeFoldable<'tcx>
+    where T : TypeFoldable<'tcx> + TransNormalize<'tcx>
 {
-    let substituted = value.subst(tcx, param_substs);
-    normalize_associated_type(tcx, &substituted)
+    let substituted = value.subst(*tcx, param_substs);
+    tcx.normalize_associated_type(&substituted)
 }


### PR DESCRIPTION
I tested this with nightly 2016-06-04.
It currently does not work with the latest nightly. Too much changed and some structs are now private. Need to find a way around that (besides ugly transmuting).

I also had to change binaryen to compile to static:

``` patch
diff --git i/CMakeLists.txt w/CMakeLists.txt
index f3f11d1..28e33e4 100644
--- i/CMakeLists.txt
+++ w/CMakeLists.txt
@@ -98,7 +98,7 @@ SET(binaryen_SOURCES
   src/cfg/Relooper.cpp
   src/wasm.cpp
 )
-ADD_LIBRARY(binaryen SHARED ${binaryen_SOURCES})
+ADD_LIBRARY(binaryen STATIC ${binaryen_SOURCES})
 TARGET_LINK_LIBRARIES(binaryen asmjs ${all_passes} support)

 SET(binaryen-shell_SOURCES
```
