### PR TITLE
Add sub, mul, and div operators

### DIFF
--- a/rust-examples/operators.rs
+++ b/rust-examples/operators.rs
@@ -1,0 +1,59 @@
+#![feature(intrinsics, lang_items, start, no_core, libc, fundamental)]
+#![no_core]
+
+#[lang = "sized"]
+#[fundamental]
+pub trait Sized { }
+
+#[lang = "add"]
+pub trait Add<RHS = Self> {
+    type Output;
+    fn add(self, rhs: RHS) -> Self::Output;
+}
+
+impl Add for isize {
+    type Output = isize;
+    fn add(self, rhs: isize) -> Self::Output { self + rhs }
+}
+
+#[lang = "sub"]
+pub trait Sub<RHS=Self> {
+    type Output;
+    fn sub(self, rhs: RHS) -> Self::Output;
+}
+
+impl Sub for isize {
+    type Output = isize;
+    fn sub(self, rhs: isize) -> Self::Output { self - rhs }
+}
+
+#[lang = "mul"]
+pub trait Mul<RHS=Self> {
+    type Output;
+    fn mul(self, rhs: RHS) -> Self::Output;
+}
+
+impl Mul for isize {
+    type Output = isize;
+    fn mul(self, rhs: isize) -> Self::Output { self * rhs }
+}
+
+#[lang = "div"]
+pub trait Div<RHS=Self> {
+    type Output;
+    fn div(self, rhs: RHS) -> Self::Output;
+}
+
+impl Div for isize {
+    type Output = isize;
+    fn div(self, rhs: isize) -> Self::Output { self / rhs }
+}
+
+fn test() {
+    main(1, 0 as _);
+}
+
+#[start]
+fn main(i: isize, _: *const *const u8) -> isize {
+    ((i + 3) * 2 - 2) / 3
+}

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -301,6 +301,9 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                     let b = self.trans_operand(b);
                     let op = match *op {
                         BinOp::Add => BinaryenAdd(),
+                        BinOp::Sub => BinaryenSub(),
+                        BinOp::Mul => BinaryenMul(),
+                        BinOp::Div => BinaryenDivS(),
                         _ => panic!()
                     };
                     Some(BinaryenBinary(self.module, op, a, b))


### PR DESCRIPTION
This PR adds those 3 operators, and also asks a lot of questions :)

An example of the wast output (manually modified to import `print`, call it inside the module, and call the exported test function so that I could check the output in binaryen-shell's interpreter): https://gist.github.com/lqd/44f627530413df83b27815808b953356

First, a comment: I'm not sure about Div. I emitted `i32.div` at first but that made the binaryen checker/interpreter trap, so I switched to `i32.div_s` which worked (maybe @kripken could weigh in on this choice ? and I will modify accordingly).

Second: adding the operators triggered some questions/thoughts
- The fun_types are a set of rust sigs, however those will be converted to wasm func types, and thus will emit duplicates. Probably not that big of a deal, considering binaryen's optimization passes remove a lot of inefficient wasm patterns (even more so in master than the version used in mir2wasm) even though this specific inefficiency of duplicates and unused func types is not yet handled in binaryen IIRC.
- Rust requires those traits & impls to compile, but those operators are wasm "intrinsics", the rust operators' code translated to wasm isn't used (and maybe shouldn't be emitted ? surely not a big deal either, binaryen will optimize them away)
- I was working on/fighting with PartialEq: in mir2wasm a lookup was done on `PartialEq::eq` (eventually, in `trans_fn_name_direct`) but the impls in the module-to-translate were more like `<isize_as_PartialEq>::eq`  -- how should this be handled ? (In my own code I hacked around this by returning the isize PartialEq::eq node id when seeing the PartialEq fn defid, but I doubt very much this is how you guys thought it should work :) -- All in all, this personally allowed me to get back to the BinOp Eq/Ne path and make it work, as well as the AddAssign trait)
- is there a plan on how the missing things in mir2wasm should work ? and at the same time maybe some "issues" would be interesting, so that we see the things you guys could use some help with ? I talked a bit about that on twitter with @kripken yesterday.
  (In my mind I was thinking mir2wasm would maybe use some of emscripten's design to model high level things -- stack frames, memory access, data segments, and so on -- and was waiting for those building blocks to appear before myself contributing on some different topics, having this "plan" and those issues would be helpful in that regard)
