### PR TITLE
Beef up the build script a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ install the current rustc nightly version:
 ```sh
 git clone https://github.com/brson/mir2wasm.git
 cd mir2wasm
-git submodule update --init
 rustup override set nightly
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,13 @@
 extern crate cmake;
 
+use std::process::Command;
+use std::path::Path;
+
 fn main() {
+    if !Path::new("binaryen/.git").exists() {
+        let _ = Command::new("git").args(&["submodule", "update", "--init"])
+                        .status();
+    }
     let dst = cmake::build("binaryen");
 
     println!("cargo:rustc-link-search=native={}/build/lib", dst.display());

--- a/build.rs
+++ b/build.rs
@@ -16,4 +16,17 @@ fn main() {
     println!("cargo:rustc-link-lib=static=support");
     println!("cargo:rustc-link-lib=static=emscripten-optimizer");
     println!("cargo:rustc-link-lib=static=asmjs");
+
+    print_deps(Path::new("binaryen"));
+}
+
+fn print_deps(path: &Path) {
+    for e in path.read_dir().unwrap().filter_map(|e| e.ok()) {
+        let file_type = e.file_type().unwrap();
+        if file_type.is_dir() {
+            print_deps(&e.path());
+        } else {
+            println!("cargo:rerun-if-changed={}", e.path().display());
+        }
+    }
 }


### PR DESCRIPTION
- Automatically clone the submodule for ease of development
- Print out dependencies to avoid unnecessarily building component
