### PR TITLE
Beginning of control flow work, and a couple other things

### DIFF
--- a/rust-examples/fibonacci.rs
+++ b/rust-examples/fibonacci.rs
@@ -1,0 +1,61 @@
+#![feature(intrinsics, lang_items, start, no_core, fundamental)]
+#![no_core]
+
+#[lang = "sized"]
+#[fundamental]
+pub trait Sized { }
+
+#[lang = "copy"]
+pub trait Copy : Clone { }
+
+pub trait Clone : Sized { }
+
+#[lang = "eq"]
+pub trait PartialEq<Rhs: ?Sized = Self> {
+    fn eq(&self, other: &Rhs) -> bool;
+
+    #[inline]
+    fn ne(&self, other: &Rhs) -> bool { !self.eq(other) }
+}
+
+impl PartialEq for isize {
+    #[inline]
+    fn eq(&self, other: &isize) -> bool { (*self) == (*other) }
+    #[inline]
+    fn ne(&self, other: &isize) -> bool { (*self) != (*other) }
+}
+
+#[lang = "add"]
+pub trait Add<RHS = Self> {
+    type Output;
+    fn add(self, rhs: RHS) -> Self::Output;
+}
+
+impl Add for isize {
+    type Output = isize;
+    fn add(self, rhs: isize) -> Self::Output { self + rhs }
+}
+
+#[lang = "sub"]
+pub trait Sub<RHS=Self> {
+    type Output;
+    fn sub(self, rhs: RHS) -> Self::Output;
+}
+
+impl Sub for isize {
+    type Output = isize;
+    fn sub(self, rhs: isize) -> Self::Output { self - rhs }
+}
+
+fn fibonacci_recursive(n: isize) -> isize {
+    if n == 0 || n == 1 {
+        n
+    } else {
+        fibonacci_recursive(n - 1) + fibonacci_recursive(n - 2)
+    }
+}
+
+#[start]
+fn main(i: isize, _: *const *const u8) -> isize {
+    fibonacci_recursive(i)
+}

--- a/rust-examples/operators.rs
+++ b/rust-examples/operators.rs
@@ -54,14 +54,14 @@ impl Div for isize {
     fn div(self, rhs: isize) -> Self::Output { self / rhs }
 }
 
-impl AddAssign for isize {
-    #[inline]
-    fn add_assign(&mut self, other: isize) { *self += other }
-}
-
 #[lang = "add_assign"]
 pub trait AddAssign<Rhs=Self> {
     fn add_assign(&mut self, Rhs);
+}
+
+impl AddAssign for isize {
+    #[inline]
+    fn add_assign(&mut self, other: isize) { *self += other }
 }
 
 #[lang = "sub_assign"]

--- a/src/bin/mir2wasm.rs
+++ b/src/bin/mir2wasm.rs
@@ -28,7 +28,10 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
         control.after_analysis.stop = rustc_driver::Compilation::Stop;
         control.after_analysis.callback = Box::new(|state| {
             state.session.abort_if_errors();
-            trans::trans_crate(&state.tcx.unwrap(), state.mir_map.unwrap())
+
+            let entry_fn = state.session.entry_fn.borrow();
+            let entry_fn = if let Some((node_id, _)) = *entry_fn { Some(node_id) } else { None };
+            trans::trans_crate(&state.tcx.unwrap(), state.mir_map.unwrap(), entry_fn)
                 .unwrap(); // FIXME
         });
 


### PR DESCRIPTION
- added branches for If terminators (would love it if @kripken would check if it's the correct way to use Relooper branches, compared to using wasm's if, etc)
- added some debug! logs to have a bit more visibility into trans
- emitting mir basic block names for wasm blocks, to have a clearer mapping to the generated wast
- added the TODO to binary ops handling regarding current i32s hard-coding (that we were talking about in #13)
- unified wording of the panic messages I added previously, to match the existing ones
- modified the mir2wasm bin to locate the entry_fn (like miri does) and adding a wasm Export to either the #[start] or #[main] fn when available (and for this, could @brson check if it's correct ? as I'm unfamiliar with the rustc_driver API and Refs here) — and since the #[main] returns nothing it could also be added as the wasm Start entry point, so I added a TODO to note that as well
- added working fibonacci example: to try it, generate the wast file, add this at the end of the file (which will work because of the "main" export):
  (assert_return (invoke "main" (i32.const 10) (i32.const 0)) (i32.const 55))
  (assert_return (invoke "main" (i32.const 20) (i32.const 0)) (i32.const 6765))
  and after building binaryen in its own subdirectory, run it with
  ./binaryen/bin/binaryen-shell (maybe even run its optimizations as well)
- started handling more than isize ConstVals (bool was required to handle the  if || in the fibonacci example)
- cosmetic change in the operators example where I had ordered a trait + its impl "wrong"
