### PR TITLE
First pass at externs

### DIFF
--- a/rust-examples/nocore-hello-world.rs
+++ b/rust-examples/nocore-hello-world.rs
@@ -34,10 +34,18 @@ extern "rust-intrinsic" { fn transmute<T, U>(t: T) -> U; }
 #[no_mangle] pub extern fn rust_eh_register_frames () {}
 #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
 
+// access to the wasm "spectest" module test printing functions
+mod wasm {
+    extern {
+        pub fn print_i32(i: isize);
+    }
+}
+
 fn real_main() {
     let i = 1;
     let j = i + 2;
-    main(j, 0 as _);
+    let result = main(j, 0 as _);
+    unsafe { wasm::print_i32(result); } // (i32.const 6)
 }
 
 #[start]

--- a/rust-examples/operators.rs
+++ b/rust-examples/operators.rs
@@ -109,6 +109,13 @@ impl PartialEq for isize {
     fn ne(&self, other: &isize) -> bool { (*self) != (*other) }
 }
 
+// access to the wasm "spectest" module test printing functions
+mod wasm {
+    extern {
+        pub fn print_i32(i: isize);
+    }
+}
+
 fn test() {
     let mut i = 0;
     i += 3;
@@ -116,7 +123,9 @@ fn test() {
     i /= 6;
     i -= 1;
     let j = i == 1;
-    main(i, 0 as _);
+
+    let result = main(i, 0 as _);
+    unsafe { wasm::print_i32(result); } // (i32.const 2)
 }
 
 #[start]


### PR DESCRIPTION
- automatically set the #[main] fn as the Module start method
- differentiated 2 of the 3 kinds of function calls
- added the print_i32 extern, and translated it to one Import and CallImport(s)
- added wasm::print_i32() to the examples with the expected results
- added i32 ConstVals and switched the fibonacci example from isizes to i32s, and
  switched from using #[start] to #[main] so it's easier to test with the interpreter.
  You can now simply run this example with binaryen-shell to have a better testing
  experience, like described in #15.
- added an iterative version of fibonacci making sure it's simple to
  not require iterators, PartialOrd, etc, and it worked without using wasms'
  loops nor changing the backend, which was surprising, but to be expected from MIR :) (& also made me wonder how do other languages target wasm, whether they use "native" loop blocks or do it with jmps)
- removed a bogus leftover comment 

yes I know I could have merged this PR myself (thanks for the collaboration invitation @brson), but just in case you guys wanted to have a look (also: I suck at git :)
