### PR TITLE
Handle the Module start function and Module exports with attributes

### DIFF
--- a/rust-examples/nocore-hello-world.rs
+++ b/rust-examples/nocore-hello-world.rs
@@ -1,4 +1,4 @@
-#![feature(intrinsics, lang_items, start, no_core, libc, fundamental)]
+#![feature(intrinsics, lang_items, start, no_core, libc, fundamental, custom_attribute)]
 #![no_core]
 
 #[lang = "sized"]
@@ -45,6 +45,9 @@ mod wasm {
     }
 }
 
+// This function will be run at Module start
+// e.g when using the interpreter
+#[wasm_start]
 fn real_main() {
     let i = 1;
     let j = i + 2;

--- a/rust-examples/operators.rs
+++ b/rust-examples/operators.rs
@@ -1,4 +1,4 @@
-#![feature(intrinsics, lang_items, start, no_core, libc, fundamental)]
+#![feature(intrinsics, lang_items, start, no_core, libc, fundamental, custom_attribute)]
 #![no_core]
 
 #[lang = "sized"]
@@ -120,6 +120,9 @@ mod wasm {
     }
 }
 
+// This function will be available to other Modules.
+// And can also be called by the interpreter at Module start (binaryen-shell -e test) 
+#[wasm_export]
 fn test() {
     let mut i = 0;
     i += 3;

--- a/src/bin/mir2wasm.rs
+++ b/src/bin/mir2wasm.rs
@@ -28,10 +28,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
         control.after_analysis.stop = rustc_driver::Compilation::Stop;
         control.after_analysis.callback = Box::new(|state| {
             state.session.abort_if_errors();
-
-            let entry_fn = state.session.entry_fn.borrow();
-            let entry_fn = if let Some((node_id, _)) = *entry_fn { Some(node_id) } else { None };
-            trans::trans_crate(&state.tcx.unwrap(), state.mir_map.unwrap(), entry_fn)
+            trans::trans_crate(&state.tcx.unwrap(), state.mir_map.unwrap())
                 .unwrap(); // FIXME
         });
 


### PR DESCRIPTION
- `#[wasm_export]` fns will be compiled as Module exports
- the `#[wasm_start]` (or `#[main]`) fn will be set as the Module start
  function
- the hello world example now has a `#[wasm_start]` method, launching the wast
  with the interpreter will run `real_main`
- the operators example shows an export of `test`, and for instance
  passing -e to the interpreter will choose the entry point:
  `binaryen-shell -e test` will execute the function
