### PR TITLE
Add `compile-pass` tests

### DIFF
--- a/src/bin/mir2wasm.rs
+++ b/src/bin/mir2wasm.rs
@@ -14,6 +14,7 @@ extern { }
 use mir2wasm::trans;
 use rustc::session::Session;
 use rustc_driver::{driver, CompilerCalls};
+use std::process;
 
 struct MiriCompilerCalls;
 
@@ -42,5 +43,8 @@ fn main() {
 
     let mut args: Vec<String> = std::env::args().collect();
     args.push("--target=arm-unknown-linux-gnueabi".to_string());
-    rustc_driver::run_compiler(&args, &mut MiriCompilerCalls);
+    match rustc_driver::run_compiler(&args, &mut MiriCompilerCalls) {
+        (Ok(_), _) => process::exit(0),
+        (Err(code), _) => process::exit(code as i32)
+    }
 }

--- a/tests/compile-pass/README.md
+++ b/tests/compile-pass/README.md
@@ -1,0 +1,3 @@
+These are tests that make it through the compiler but do not necessarily
+run. These should be equivalent to the run-pass tests, but we aren't quite there
+yet.

--- a/tests/compile-pass/enum.rs
+++ b/tests/compile-pass/enum.rs
@@ -1,0 +1,24 @@
+// xfail
+
+#![feature(lang_items, no_core)]
+#![allow(dead_code)]
+#![no_core]
+
+#[lang="sized"]
+trait Sized {}
+
+#[lang="copy"]
+trait Copy {}
+
+enum Tag {
+    A(isize),
+    B(isize)
+}
+
+fn main() {
+    let a = Tag::A(5);
+    match a {
+        Tag::A(i) => i,
+        Tag::B(i) => i,
+    };
+}

--- a/tests/compile-pass/trivial.rs
+++ b/tests/compile-pass/trivial.rs
@@ -1,12 +1,7 @@
-#![allow(dead_code)]
-#![no_std]
+#![feature(lang_items, no_core)]
 #![no_core]
 
-fn empty() {}
-
-fn unit_var() {
-    let x = ();
-    x
-}
+#[lang="sized"]
+trait Sized {}
 
 fn main() {}

--- a/tests/compile-pass/trivial.rs
+++ b/tests/compile-pass/trivial.rs
@@ -1,0 +1,12 @@
+#![allow(dead_code)]
+#![no_std]
+#![no_core]
+
+fn empty() {}
+
+fn unit_var() {
+    let x = ();
+    x
+}
+
+fn main() {}

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -3,7 +3,9 @@ extern crate compiletest_rs as compiletest;
 use std::path::{PathBuf, Path};
 use std::io::Write;
 
-fn compile_fail(sysroot: &str) {
+#[test] #[ignore]
+fn compile_fail() {
+    let sysroot = &find_sysroot();
     let flags = format!("--sysroot {} -Dwarnings", sysroot);
     for_all_targets(sysroot, |target| {
         let mut config = compiletest::default_config();
@@ -18,6 +20,48 @@ fn compile_fail(sysroot: &str) {
     });
 }
 
+#[test]
+fn compile_pass() {
+    let sysroot = find_sysroot();
+    for_all_targets(&sysroot, |target| {
+        for file in std::fs::read_dir("tests/compile-pass").unwrap() {
+            let file = file.unwrap();
+            let path = file.path();
+
+            if !file.metadata().unwrap().is_file() || !path.to_str().unwrap().ends_with(".rs") {
+                continue;
+            }
+
+            let stderr = std::io::stderr();
+            write!(stderr.lock(), "test [compile-pass] {} ... ", path.display()).unwrap();
+            let mut cmd = std::process::Command::new("target/debug/mir2wasm");
+            cmd.arg(path);
+            cmd.arg("-Dwarnings");
+            let libs = Path::new(&sysroot).join("lib");
+            let sysroot = libs.join("rustlib").join(&target).join("lib");
+            let paths = std::env::join_paths(&[libs, sysroot]).unwrap();
+            cmd.env(compiletest::procsrv::dylib_env_var(), paths);
+
+            match cmd.output() {
+                Ok(ref output) if output.status.success() => writeln!(stderr.lock(), "ok").unwrap(),
+                Ok(output) => {
+                    writeln!(stderr.lock(), "FAILED with exit code {:?}", output.status.code()).unwrap();
+                    writeln!(stderr.lock(), "stdout: \n {}", std::str::from_utf8(&output.stdout).unwrap()).unwrap();
+                    writeln!(stderr.lock(), "stderr: \n {}", std::str::from_utf8(&output.stderr).unwrap()).unwrap();
+                    panic!("some tests failed");
+                }
+                Err(e) => {
+                    writeln!(stderr.lock(), "FAILED: {}", e).unwrap();
+                    panic!("some tests failed");
+                },
+            }
+        }
+        let stderr = std::io::stderr();
+        writeln!(stderr.lock(), "").unwrap();
+    });
+}
+
+#[test]
 fn run_pass() {
     let mut config = compiletest::default_config();
     config.mode = "run-pass".parse().expect("Invalid mode");
@@ -25,41 +69,9 @@ fn run_pass() {
     compiletest::run_tests(&config);
 }
 
-fn for_all_targets<F: FnMut(String)>(sysroot: &str, mut f: F) {
-    for target in std::fs::read_dir(format!("{}/lib/rustlib/", sysroot)).unwrap() {
-        let target = target.unwrap();
-        if !target.metadata().unwrap().is_dir() {
-            continue;
-        }
-        let target = target.file_name().into_string().unwrap();
-        if target == "etc" {
-            continue;
-        }
-        let stderr = std::io::stderr();
-        writeln!(stderr.lock(), "running tests for target {}", target).unwrap();
-        f(target);
-    }
-}
-
-#[test]
-fn empty_test() {
-    // show the test harness is running by getting at least one
-    // successful test.
-}
-
 #[test] #[ignore]
-fn compile_test() {
-    // Taken from https://github.com/Manishearth/rust-clippy/pull/911.
-    let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
-    let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
-    let sysroot = match (home, toolchain) {
-        (Some(home), Some(toolchain)) => format!("{}/toolchains/{}", home, toolchain),
-        _ => option_env!("RUST_SYSROOT")
-            .expect("need to specify RUST_SYSROOT env var or use rustup or multirust")
-            .to_owned(),
-    };
-    compile_fail(&sysroot);
-    run_pass();
+fn miri_run_pass() {
+    let sysroot = find_sysroot();
     for_all_targets(&sysroot, |target| {
         for file in std::fs::read_dir("tests/run-pass").unwrap() {
             let file = file.unwrap();
@@ -71,7 +83,7 @@ fn compile_test() {
 
             let stderr = std::io::stderr();
             write!(stderr.lock(), "test [miri-pass] {} ... ", path.display()).unwrap();
-            let mut cmd = std::process::Command::new("target/debug/miri");
+            let mut cmd = std::process::Command::new("target/debug/mir2wasm");
             cmd.arg(path);
             cmd.arg("-Dwarnings");
             cmd.arg(format!("--target={}", target));
@@ -97,4 +109,38 @@ fn compile_test() {
         let stderr = std::io::stderr();
         writeln!(stderr.lock(), "").unwrap();
     });
+}
+
+fn for_all_targets<F: FnMut(String)>(sysroot: &str, mut f: F) {
+    for target in std::fs::read_dir(format!("{}/lib/rustlib/", sysroot)).unwrap() {
+        let target = target.unwrap();
+        if !target.metadata().unwrap().is_dir() {
+            continue;
+        }
+        let target = target.file_name().into_string().unwrap();
+        if target == "etc" {
+            continue;
+        }
+        let stderr = std::io::stderr();
+        writeln!(stderr.lock(), "running tests for target {}", target).unwrap();
+        f(target);
+    }
+}
+
+#[test]
+fn empty_test() {
+    // show the test harness is running by getting at least one
+    // successful test.
+}
+
+fn find_sysroot() -> String {
+    // Taken from https://github.com/Manishearth/rust-clippy/pull/911.
+    let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
+    let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
+    match (home, toolchain) {
+        (Some(home), Some(toolchain)) => format!("{}/toolchains/{}", home, toolchain),
+        _ => option_env!("RUST_SYSROOT")
+            .expect("need to specify RUST_SYSROOT env var or use rustup or multirust")
+            .to_owned(),
+    }
 }


### PR DESCRIPTION
Adds a new category to `cargo test` that checks whether files compile using `mir2wasm`, but does not bother to run them. In time these should become a superset of, or even equal to, the run-pass tests.

The test runner will automatically skip over any files that contain `xfail`. This can be used for tests that should pass but we know they won't right now, such as when they rely on a feature that is not yet implemented.

This change also includes some refactoring of the previous compile tests, and modifies `mir2wasm` to return an exit status that reflects whether compilation succeeded. We should probably just remove the miri-pass tests, but I'm leaving them for now in case they are a useful reference to getting run-pass to work with some kind of interpreter.

Issue #15 
