### PR TITLE
Switch back to WebAssembly/binaryen, and first Memory features

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "binaryen"]
 	path = binaryen
-	url = https://github.com/brson/binaryen.git
+	url = https://github.com/WebAssembly/binaryen.git

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,9 @@ fn main() {
         let _ = Command::new("git").args(&["submodule", "update", "--init"])
                         .status();
     }
-    let dst = cmake::build("binaryen");
+    let dst = cmake::Config::new("binaryen")
+                 .define("BUILD_STATIC_LIB", "ON")
+                 .build();
 
     println!("cargo:rustc-link-search=native={}/build/lib", dst.display());
     println!("cargo:rustc-link-lib=static=binaryen");

--- a/rust-examples/nocore-hello-world.rs
+++ b/rust-examples/nocore-hello-world.rs
@@ -1,4 +1,4 @@
-#![feature(intrinsics, lang_items, start, no_core, libc, fundamental, custom_attribute)]
+#![feature(intrinsics, lang_items, start, no_core, libc, fundamental)]
 #![no_core]
 
 #[lang = "sized"]
@@ -45,14 +45,10 @@ mod wasm {
     }
 }
 
-// This function will be run at Module start
-// e.g when using the interpreter
-#[wasm_start]
-fn real_main() {
+fn real_main() -> isize {
     let i = 1;
     let j = i + 2;
-    let result = main(j, 0 as _);
-    wasm::print_i32(result); // (i32.const 6)
+    j
 }
 
 #[start]
@@ -61,5 +57,8 @@ fn main(i: isize, _: *const *const u8) -> isize {
         let (ptr, _): (*const u8, usize) = transmute("Hello!\0");
         puts(ptr);
 }*/
-    return i + 3;
+
+    let result = real_main() + 3;
+    wasm::print_i32(result); // (i32.const 6)
+    result
 }

--- a/rust-examples/operators.rs
+++ b/rust-examples/operators.rs
@@ -1,4 +1,4 @@
-#![feature(intrinsics, lang_items, start, no_core, libc, fundamental, custom_attribute)]
+#![feature(intrinsics, lang_items, main, no_core, fundamental)]
 #![no_core]
 
 #[lang = "sized"]
@@ -120,10 +120,12 @@ mod wasm {
     }
 }
 
-// This function will be available to other Modules.
-// And can also be called by the interpreter at Module start (binaryen-shell -e test) 
-#[wasm_export]
-fn test() {
+fn test(i: isize) -> isize {
+    ((i + 3) * 2 - 2) / 3
+}
+
+#[main]
+fn main() {
     let mut i = 0;
     i += 3;
     i *= 4;
@@ -131,11 +133,6 @@ fn test() {
     i -= 1;
     let j = i == 1;
 
-    let result = main(i, 0 as _);
+    let result = test(i);
     wasm::print_i32(result); // (i32.const 2)
-}
-
-#[start]
-fn main(i: isize, _: *const *const u8) -> isize {
-    ((i + 3) * 2 - 2) / 3
 }

--- a/rust-examples/struct.rs
+++ b/rust-examples/struct.rs
@@ -1,0 +1,53 @@
+#![feature(intrinsics, lang_items, main, no_core, fundamental)]
+#![no_core]
+
+#[lang = "sized"]
+#[fundamental]
+pub trait Sized { }
+
+#[lang = "copy"]
+pub trait Copy : Clone { }
+
+pub trait Clone : Sized { }
+
+#[lang = "mul"]
+pub trait Mul<RHS=Self> {
+    type Output;
+    fn mul(self, rhs: RHS) -> Self::Output;
+}
+
+impl Mul for i32 {
+    type Output = i32;
+    fn mul(self, rhs: i32) -> Self::Output { self * rhs }
+}
+
+// access to the wasm "spectest" module test printing functions
+mod wasm {
+    pub fn print_i32(i: i32) {
+        unsafe { _print_i32(i); }
+    }
+
+    extern {
+        fn _print_i32(i: i32);
+    }
+}
+
+struct Rectangle {
+    w: i32,
+    h: i32,
+}
+
+impl Rectangle {
+    fn area(&self) -> i32 {
+        self.w * self.h
+    }
+}
+
+#[main]
+fn main() {
+    let mut r = Rectangle {w: 2, h: 5};
+    wasm::print_i32(r.area()); // (i32.const 10)
+
+    r.w = 3;
+    wasm::print_i32(r.area()); // (i32.const 15)
+}

--- a/src/binaryen.rs
+++ b/src/binaryen.rs
@@ -274,6 +274,8 @@ extern {
 
     pub fn BinaryenModuleRead(input: *const c_char, inputSize: size_t) -> BinaryenModuleRef;
 
+    pub fn BinaryenModuleInterpret(module: BinaryenModuleRef);
+
     // CFG / Relooper
 
     pub fn RelooperCreate() -> RelooperRef;

--- a/src/binaryen.rs
+++ b/src/binaryen.rs
@@ -237,6 +237,7 @@ extern {
     pub fn BinaryenHost(module: BinaryenModuleRef, op: BinaryenOp, name: *const c_char, operands: *const BinaryenExpressionRef, numOperands: BinaryenIndex) -> BinaryenExpressionRef;
     pub fn BinaryenNop(module: BinaryenModuleRef) -> BinaryenExpressionRef;
     pub fn BinaryenUnreachable(module: BinaryenModuleRef) -> BinaryenExpressionRef;
+    pub fn BinaryenExpressionPrint(expr: BinaryenExpressionRef);
 
     // Functions
 

--- a/src/monomorphize.rs
+++ b/src/monomorphize.rs
@@ -1,5 +1,5 @@
 use rustc::ty::subst::{Subst, Substs};
-use rustc::ty::{TyCtxt, TypeFoldable};
+use rustc::ty::{Ty, TyCtxt, TypeFoldable};
 use rustc::infer::TransNormalize;
 
 pub fn apply_param_substs<'a, 'tcx,T>(tcx: &TyCtxt<'a, 'tcx, 'tcx>,
@@ -9,5 +9,14 @@ pub fn apply_param_substs<'a, 'tcx,T>(tcx: &TyCtxt<'a, 'tcx, 'tcx>,
     where T : TypeFoldable<'tcx> + TransNormalize<'tcx>
 {
     let substituted = value.subst(*tcx, param_substs);
+    tcx.normalize_associated_type(&substituted)
+}
+
+pub fn apply_ty_substs<'a, 'tcx>(tcx: &TyCtxt<'a, 'tcx, 'tcx>,
+                                 ty_substs: &Substs<'tcx>,
+                                 ty: Ty<'tcx>)
+                                 -> Ty<'tcx>    
+{
+    let substituted = ty.subst(*tcx, ty_substs);
     tcx.normalize_associated_type(&substituted)
 }

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -5,9 +5,12 @@ use rustc::mir::mir_map::MirMap;
 use rustc::middle::const_val::ConstVal;
 use rustc_const_math::{ConstInt, ConstIsize};
 use rustc::ty::{self, TyCtxt, Ty, FnSig};
+use rustc::ty::layout::{self, Layout, Size};
+use rustc::ty::subst::Substs;
 use rustc::hir::intravisit::{self, Visitor, FnKind};
 use rustc::hir::{FnDecl, Block};
 use rustc::hir::def_id::DefId;
+use rustc::traits::ProjectionMode;
 use syntax::ast::{NodeId, IntTy, UintTy, FloatTy};
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
@@ -35,9 +38,20 @@ pub fn trans_crate<'a, 'tcx>(tcx: &TyCtxt<'a, 'tcx, 'tcx>,
     tcx.map.krate().visit_all_items(v);
 
     unsafe {
-        // TODO: validate the module
-        // TODO: make it possible to print the optimized module
+        // TODO: add CLI options to optimize the module: -O ? --release ? or optimize it always ?
+        // TODO: check which of the optimization passes we want aren't on by default here.
+        //       eg, removing unused functions and imports, minification, etc
+        // BinaryenModuleOptimize(v.module);
+
+        assert!(BinaryenModuleValidate(v.module) == 1, "Internal compiler error: invalid generated module");
+
         BinaryenModulePrint(v.module);
+
+        // TODO: add CLI option to launch the interpreter: --run ?
+        // BinaryenModuleInterpret(v.module);
+
+        // TODO: add CLI option to save the module to a specified file: -o ?
+        // BinaryenModuleWrite(v.module, ...)
     }
 
     Ok(())
@@ -161,7 +175,11 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
             locals.push(binaryen_ret);
         }
 
-        // reelooper helper for irreducible control flow
+        // Function prologue: stack pointer
+        locals.push(BinaryenInt32());
+        let stack_pointer_local = BinaryenIndex(locals.len() as _);
+
+        // relooper helper for irreducible control flow
         locals.push(BinaryenInt32());
         let relooper_local = BinaryenIndex(locals.len() as _);
 
@@ -183,13 +201,8 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
             let mut binaryen_stmts = Vec::new();
             for stmt in &bb.statements {
                 match stmt.kind {
-                    StatementKind::Assign(ref lval, ref rval) => {
-                        let (lval_i, _) = self.trans_lval(lval);
-                        if let Some(rval_expr) = self.trans_rval(rval) {
-                            debug!("emitting SetLocal for Assign '{:?} = {:?}'", lval, rval);
-                            let binaryen_stmt = unsafe { BinaryenSetLocal(self.module, lval_i, rval_expr) };
-                            binaryen_stmts.push(binaryen_stmt);
-                        }
+                    StatementKind::Assign(ref lvalue, ref rvalue) => {
+                        self.trans_assignment(lvalue, rvalue, &mut binaryen_stmts);
                     }
                 }
             }
@@ -199,6 +212,15 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
             // are the expressions.
             match bb.terminator().kind {
                 TerminatorKind::Return => {
+                    // Emit function epilogue:
+                    // TODO: like the prologue, not always necessary
+                    unsafe {
+                        let sp = BinaryenConst(self.module, BinaryenLiteralInt32(0));
+                        let read_original_sp = BinaryenGetLocal(self.module, stack_pointer_local, BinaryenInt32());
+                        let restore_original_sp = BinaryenStore(self.module, 4, 0, 0, sp, read_original_sp);
+                        binaryen_stmts.push(restore_original_sp);
+                    }
+
                     debug!("emitting Return from fn {:?}", self.tcx.item_path_str(self.did));
                     let expr = self.trans_operand(&Operand::Consume(Lvalue::ReturnPointer));
                     let expr = unsafe { BinaryenReturn(self.module, expr) };
@@ -228,7 +250,7 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
 
                         match *destination {
                             Some((ref lvalue, _)) => {
-                                let b_lvalue = self.trans_lval(lvalue);
+                                let (lvalue_index, _) = self.trans_lval(lvalue);
 
                                 if b_fnty == BinaryenNone() {
                                     // The result of the Rust call is put in MIR into a tmp local,
@@ -237,11 +259,11 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                                     debug!("emitting {:?} Call to fn {:?} + SetLocal for unit type", call_kind, func);
                                     binaryen_stmts.push(b_call);
 
-                                    let unit_type = BinaryenConst(self.module, BinaryenLiteralInt32(0));
-                                    binaryen_stmts.push(BinaryenSetLocal(self.module, b_lvalue.0, unit_type));
+                                    let unit_type = BinaryenConst(self.module, BinaryenLiteralInt32(-1));
+                                    binaryen_stmts.push(BinaryenSetLocal(self.module, lvalue_index, unit_type));
                                 } else {
                                     debug!("emitting {:?} Call to fn {:?} + SetLocal of the result", call_kind, func);
-                                    binaryen_stmts.push(BinaryenSetLocal(self.module, b_lvalue.0, b_call));
+                                    binaryen_stmts.push(BinaryenSetLocal(self.module, lvalue_index, b_call));
                                 }
                             }
                             _ => {
@@ -331,41 +353,165 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                 self.fun_types.insert(self.sig.clone(), ty);
             }
 
+            // Create the function prologue
+            // TODO: the epilogue and prologue are not always necessary
+            let read_sp = BinaryenLoad(self.module, 4, 0, 0, 0, BinaryenInt32(),
+                                       BinaryenConst(self.module, BinaryenLiteralInt32(0)));
+            let copy_sp = BinaryenSetLocal(self.module, stack_pointer_local, read_sp);
+            let prologue = RelooperAddBlock(relooper, copy_sp);
+            relooper_blocks.insert(0, prologue);
+
+            if relooper_blocks.len() > 1 {
+                RelooperAddBranch(relooper_blocks[0], relooper_blocks[1],
+                                  BinaryenExpressionRef(ptr::null_mut()),
+                                  BinaryenExpressionRef(ptr::null_mut()));
+            }
+
             let body = RelooperRenderAndDispose(relooper,
                                                 relooper_blocks[0],
                                                 relooper_local,
                                                 self.module);
-            let f = BinaryenAddFunction(self.module, fn_name_ptr,
-                                        *self.fun_types.get(self.sig).unwrap(),
-                                        locals.as_ptr(),
-                                        BinaryenIndex(locals.len() as _),
-                                        body);
+            BinaryenAddFunction(self.module, fn_name_ptr,
+                                *self.fun_types.get(self.sig).unwrap(),
+                                locals.as_ptr(),
+                                BinaryenIndex(locals.len() as _),
+                                body);
 
             let nid = self.tcx.map.as_local_node_id(self.did).expect("");
             let attrs = self.tcx.map.attrs(nid);
 
-            let wasm_export_fn = attrs.iter().filter(|&attr| "wasm_export" == attr.node.value.name()).count() > 0;
-            if wasm_export_fn {
-                debug!("emitting Export for fn {:?}", self.tcx.item_path_str(self.did));
-                BinaryenAddExport(self.module, fn_name_ptr, fn_name_ptr);
-            }
-
-            // TODO: there should be a compilation failure if more than one wasm start fn is found
-            let wasm_start_fn = attrs.iter().filter(|&attr| {
-                let name = attr.node.value.name();
-                name == "wasm_start" || name == "main"
-            }).count() > 0;
-
-            if wasm_start_fn {
-                debug!("emitting SetStart for fn {:?}", self.tcx.item_path_str(self.did));
-                BinaryenSetStart(self.module, f);
+            // Look for the entry fns attributes, and call them from the generated runtime start fn
+            for attr in attrs {
+                let name = attr.node.value.name().to_string();
+                if name == "start" || name == "main" {
+                    let wasm_start = self.generate_runtime_start(&name);
+                    debug!("emitting wasm Start fn into fn {:?}", self.tcx.item_path_str(self.did));
+                    BinaryenSetStart(self.module, wasm_start);
+                }
             }
         }
 
         debug!("done translating fn {:?}\n", self.tcx.item_path_str(self.did));
     }
 
-    fn trans_lval(&mut self, lvalue: &Lvalue) -> (BinaryenIndex, u32) {
+    fn trans_assignment(&mut self, lvalue: &Lvalue<'tcx>, rvalue: &Rvalue<'tcx>, statements: &mut Vec<BinaryenExpressionRef>) {
+        let (lvalue_index, lvalue_offset) = self.trans_lval(lvalue);
+        let dest_ty = self.mir.lvalue_ty(*self.tcx, lvalue).to_ty(*self.tcx);
+
+        match *rvalue {
+            Rvalue::Use(ref operand) => {
+                let src = self.trans_operand(operand);
+
+                unsafe {
+                    let statement = match lvalue_offset {
+                        Some(offset) => {
+                            debug!("emitting Store + GetLocal for Assign Use '{:?} = {:?}'", lvalue, rvalue);
+                            let ptr = BinaryenGetLocal(self.module, lvalue_index, rust_ty_to_binaryen(dest_ty));
+                            // TODO: match on the dest_ty to know how many bytes to write, not just i32s
+                            BinaryenStore(self.module, 4, offset * 8, 0, ptr, src)
+                        }
+                        None => {
+                            debug!("emitting SetLocal for Assign Use '{:?} = {:?}'", lvalue, rvalue);
+                            BinaryenSetLocal(self.module, lvalue_index, src)
+                        }
+                    };
+                    statements.push(statement);
+                }
+            }
+
+            Rvalue::BinaryOp(ref op, ref left, ref right) => {
+                let left = self.trans_operand(left);
+                let right = self.trans_operand(right);
+
+                unsafe {
+                    // TODO: match on dest_ty.sty to implement binary ops for other types than just i32s
+                    let op = match *op {
+                        BinOp::Add => BinaryenAddInt32(),
+                        BinOp::Sub => BinaryenSubInt32(),
+                        BinOp::Mul => BinaryenMulInt32(),
+                        BinOp::Div => BinaryenDivSInt32(),
+                        BinOp::Eq => BinaryenEqInt32(),
+                        BinOp::Ne => BinaryenNeInt32(),
+                        _ => panic!("unimplemented BinOp: {:?}", op)
+                    };
+
+                    debug!("emitting SetLocal for Assign BinaryOp '{:?} = {:?}'", lvalue, rvalue);
+                    let op = BinaryenBinary(self.module, op, left, right);
+                    statements.push(BinaryenSetLocal(self.module, lvalue_index, op));
+                }
+            }
+
+            Rvalue::Ref( _, _, ref lvalue) => {
+                // TODO: for shared refs only ?
+                // TODO: works for refs to "our stack", but not the locals on the wasm stack yet
+                let expr = self.trans_operand(&Operand::Consume(lvalue.clone()));
+                unsafe {
+                    debug!("emitting SetLocal for Assign Ref '{:?} = {:?}'", lvalue, rvalue);
+                    let expr = BinaryenSetLocal(self.module, lvalue_index, expr);
+                    statements.push(expr);
+                }
+            }
+
+            Rvalue::Aggregate (ref kind, ref operands) => {
+                match *kind {
+                    AggregateKind::Adt(ref adt_def, _, ref substs) => {
+                        let dest_layout = self.type_layout_with_substs(dest_ty, substs);
+
+                        // TODO: check sizes, alignments (abi vs preferred), etc
+                        let dest_size = self.type_size_with_substs(dest_ty, substs) as i32 * 8;
+
+                        match *dest_layout {
+                            Layout::Univariant { ref variant, .. } => {
+                                // NOTE: use the variant's min_size and alignment for dest_size ?
+                                // TODO: extract the following into the Memory abstraction as well
+                                unsafe {
+                                    // alloca
+                                    debug!("allocating struct {:?} in linear memory, size: {:?} bytes ", adt_def, dest_size);
+
+                                    let sp = BinaryenConst(self.module, BinaryenLiteralInt32(0));
+                                    let read_sp = BinaryenLoad(self.module, 4, 0, 0, 0, BinaryenInt32(), sp);
+
+                                    let dest_size = BinaryenConst(self.module, BinaryenLiteralInt32(dest_size));
+                                    let decr_sp = BinaryenBinary(self.module, BinaryenSubInt32(), read_sp, dest_size);
+                                    let write_sp = BinaryenStore(self.module, 4, 0, 0, sp, decr_sp);
+                                    let write_local = BinaryenSetLocal(self.module, lvalue_index, write_sp);
+                                    statements.push(write_local);
+
+                                    // set fields
+                                    let offsets = ::std::iter::once(0).chain(variant.offset_after_field.iter().map(|s| s.bytes()));
+                                    for (offset, operand) in offsets.into_iter().zip(operands) {
+                                        // let operand_ty = self.mir.operand_ty(*self.tcx, operand);
+                                        // TODO: match on the operand_ty to know how many bytes to store, not just i32s
+
+                                        let src = self.trans_operand(operand);
+                                        let write_field = BinaryenStore(self.module, 4, offset as u32 * 8, 0, read_sp, src);
+                                        debug!("emitting Store field, offset {:?}, value '{:?}'", offset * 8, operand);
+                                        statements.push(write_field);
+                                    }
+                                }
+                            }
+                            _ => panic!("unimplemented Assign Aggregate Adt {:?} on Layout {:?}", adt_def, dest_layout)
+                        }
+                    }
+
+                    AggregateKind::Tuple => {
+                        if operands.len() == 0 {
+                            // TODO: in general, have a consistent strategy to handle the unit type assigns/returns
+                            debug!("ignoring Assign '{:?} = {:?}'", lvalue, rvalue);
+                        } else {
+                            panic!("unimplemented Assign '{:?} = {:?}'", lvalue, rvalue);
+                        }
+                    }
+
+                    _ => panic!("unimplemented Assign Aggregate {:?}", kind)
+                }
+            }
+
+            _ => panic!("unimplemented Assign '{:?} = {:?}'", lvalue, rvalue)
+        }
+    }
+
+    fn trans_lval(&mut self, lvalue: &Lvalue<'tcx>) -> (BinaryenIndex, Option<u32>) {
         let i = match *lvalue {
             Lvalue::Arg(i) => i,
             Lvalue::Var(i) => self.mir.arg_decls.len() as u32 + i,
@@ -379,72 +525,78 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                     self.mir.temp_decls.len() as u32
             }
             Lvalue::Projection(ref projection) => {
-                if projection.elem == ProjectionElem::Deref {
-                    let (i, _) = self.trans_lval(&projection.base);
-                    i.0
-                } else {
-                    panic!("unimplemented ProjectionElem: {:?}", projection.elem);
+                let (base, offset) = self.trans_lval(&projection.base);
+                let base_ty = self.mir.lvalue_ty(*self.tcx, &projection.base).to_ty(*self.tcx);
+
+                // TODO: Actually, those substs should probably be collected for the whole frame, like miri does
+                let substs = self.tcx.mk_substs(Substs::empty());
+                let base_layout = self.type_layout_with_substs(base_ty, substs);
+
+                match projection.elem {
+                    ProjectionElem::Deref => {
+                        if offset.is_none() {
+                            return (base, None);
+                        }
+                        panic!("unimplemented Deref {:?}", lvalue);
+                    }
+                    ProjectionElem::Field(ref field, _) => {
+                        let variant = match *base_layout {
+                            Layout::Univariant { ref variant, .. } => variant,
+                            _ => panic!("unimplemented Field Projection: {:?}", projection)
+                        };
+
+                        let offset = variant.field_offset(field.index()).bytes();
+                        return (base, Some(offset as u32));
+                    }
+                    _ => panic!("unimplemented Projection: {:?}", projection)
                 }
             }
             _ => panic!("unimplemented Lvalue: {:?}", lvalue)
         };
 
-        (BinaryenIndex(i), 0)
-    }
-
-    fn trans_rval(&mut self, rvalue: &Rvalue<'tcx>) -> Option<BinaryenExpressionRef> {
-        unsafe {
-            match *rvalue {
-                Rvalue::Use(ref operand) => {
-                    Some(self.trans_operand(operand))
-                }
-                Rvalue::BinaryOp(ref op, ref a, ref b) => {
-                    let a = self.trans_operand(a);
-                    let b = self.trans_operand(b);
-                    // TODO: implement binary ops for other types than just i32s
-                    let op = match *op {
-                        BinOp::Add => BinaryenAddInt32(),
-                        BinOp::Sub => BinaryenSubInt32(),
-                        BinOp::Mul => BinaryenMulInt32(),
-                        BinOp::Div => BinaryenDivSInt32(),
-                        BinOp::Eq => BinaryenEqInt32(),
-                        BinOp::Ne => BinaryenNeInt32(),
-                        _ => panic!("unimplemented BinOp: {:?}", op)
-                    };
-                    Some(BinaryenBinary(self.module, op, a, b))
-                }
-                Rvalue::Ref( _, _, ref lvalue) => {
-                    // TODO: for shared refs, similar to Operand::Consume and could be shared
-                    let (i, _) = self.trans_lval(lvalue);
-                    let lval_ty = self.mir.lvalue_ty(*self.tcx, lvalue);
-                    let t = lval_ty.to_ty(*self.tcx);
-                    let t = rust_ty_to_binaryen(t);
-                    Some(BinaryenGetLocal(self.module, i, t))
-                }
-                _ => {
-                    None
-                }
-            }
-        }
+        (BinaryenIndex(i), None)
     }
 
     fn trans_operand(&mut self, operand: &Operand<'tcx>) -> BinaryenExpressionRef {
         match *operand {
             Operand::Consume(ref lvalue) => {
-                let (i, _) = self.trans_lval(lvalue);
+                let (index, offset) = self.trans_lval(lvalue);
                 let lval_ty = self.mir.lvalue_ty(*self.tcx, lvalue);
                 let t = lval_ty.to_ty(*self.tcx);
                 let t = rust_ty_to_binaryen(t);
-                unsafe { BinaryenGetLocal(self.module, i, t) }
+
+                unsafe {
+                    match offset {
+                        Some(offset) => {
+                            debug!("emitting GetLocal + Load for '{:?}'", lvalue);
+                            let ptr = BinaryenGetLocal(self.module, index, t);
+                            // TODO: match on the field ty to know how many bytes to read, not just i32s
+                            BinaryenLoad(self.module, 4, 0, offset * 8, 0, BinaryenInt32(), ptr)
+                        }
+                        None => {
+                            // debug!("emitting GetLocal for '{:?}'", lvalue);
+                            BinaryenGetLocal(self.module, index, t)
+                        }
+                    }
+                }
             }
             Operand::Constant(ref c) => {
                 match c.literal {
                     Literal::Value { ref value } => {
+                        // TODO: handle more Rust types here, and cleanup the match
+                        //       to return a single BinaryenLiteral if possible
                         match *value {
                             ConstVal::Integral(ConstInt::Isize(ConstIsize::Is32(val))) |
                             ConstVal::Integral(ConstInt::I32(val)) => {
                                 unsafe {
                                     let lit = BinaryenLiteralInt32(val);
+                                    BinaryenConst(self.module, lit)
+                                }
+                            }
+                            ConstVal::Integral(ConstInt::Isize(ConstIsize::Is64(val))) |
+                            ConstVal::Integral(ConstInt::I64(val)) => {
+                                unsafe {
+                                    let lit = BinaryenLiteralInt64(val);
                                     BinaryenConst(self.module, lit)
                                 }
                             }
@@ -467,6 +619,22 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
         }
     }
 
+    // Imported from miri
+    fn type_size_with_substs(&self, ty: Ty<'tcx>, substs: &'tcx Substs<'tcx>) -> usize {
+        self.type_layout_with_substs(ty, substs).size(&self.tcx.data_layout).bytes() as usize
+    }
+
+    // Imported from miri and slightly modified to adapt to our monomorphize api
+    fn type_layout_with_substs(&self, ty: Ty<'tcx>, substs: &'tcx Substs<'tcx>) -> &'tcx Layout {
+        // TODO(solson): Is this inefficient? Needs investigation.
+        let ty = monomorphize::apply_ty_substs(self.tcx, substs, ty);
+
+        self.tcx.normalizing_infer_ctxt(ProjectionMode::Any).enter(|infcx| {
+            // TODO(solson): Report this error properly.
+            ty.layout(&infcx).unwrap()
+        })
+    }
+
     fn trans_fn_name_direct(&mut self, operand: &Operand<'tcx>) -> Option<(*const c_char, BinaryenType, BinaryenCallKind)> {
         match *operand {
             Operand::Constant(ref c) => {
@@ -482,47 +650,50 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                             let fn_sig;
                             let mut call_kind = BinaryenCallKind::Direct;
 
-                            if fn_name == "wasm::::print_i32" || fn_name == "wasm::::_print_i32" {
-                                // extern wasm functions
-                                fn_sig = sig.clone();
-                                call_kind = BinaryenCallKind::Import;
-                                self.import_wasm_extern(fn_did, sig);
-                            } else {
-                                let nid = self.tcx.map.as_local_node_id(fn_did).expect("");
-                                let (nid, substs, sig) = if self.mir_map.map.contains_key(&nid) {
-                                    (nid, *substs, sig)
-                                } else {
-                                    // only trait methods can have a Self parameter
-                                    if substs.self_ty().is_none() {
-                                        panic!("unimplemented fn trans: {:?}", fn_did);
-                                    }
+                            match fn_name.as_ref() {
+                                "wasm::::print_i32" | "wasm::::_print_i32" => {
+                                    // extern wasm functions
+                                    fn_sig = sig.clone();
+                                    call_kind = BinaryenCallKind::Import;
+                                    self.import_wasm_extern(fn_did, sig);
+                                }
+                                _ => {
+                                    let nid = self.tcx.map.as_local_node_id(fn_did).expect("");
+                                    let (nid, substs, sig) = if self.mir_map.map.contains_key(&nid) {
+                                        (nid, *substs, sig)
+                                    } else {
+                                        // only trait methods can have a Self parameter
+                                        if substs.self_ty().is_none() {
+                                            panic!("unimplemented fn trans: {:?}", fn_did);
+                                        }
 
-                                    let (resolved_def_id, resolved_substs) = traits::resolve_trait_method(self.tcx, fn_did, substs);
-                                    let nid = self.tcx.map.as_local_node_id(resolved_def_id).expect("");
-                                    let ty = self.tcx.lookup_item_type(resolved_def_id).ty;
-                                    let sig = ty.fn_sig().skip_binder();
+                                        let (resolved_def_id, resolved_substs) = traits::resolve_trait_method(self.tcx, fn_did, substs);
+                                        let nid = self.tcx.map.as_local_node_id(resolved_def_id).expect("");
+                                        let ty = self.tcx.lookup_item_type(resolved_def_id).ty;
+                                        let sig = ty.fn_sig().skip_binder();
 
-                                    fn_did = resolved_def_id;
-                                    (nid, resolved_substs, sig)
-                                };
-
-                                let mir = &self.mir_map.map[&nid];
-
-                                fn_sig = monomorphize::apply_param_substs(self.tcx, substs, sig);
-                                {
-                                    let mut ctxt = BinaryenFnCtxt {
-                                        tcx: self.tcx,
-                                        mir_map: self.mir_map,
-                                        mir: mir,
-                                        did: fn_did,
-                                        sig: &fn_sig,
-                                        module: self.module,
-                                        fun_types: &mut self.fun_types,
-                                        fun_names: &mut self.fun_names,
-                                        c_strings: &mut self.c_strings,
+                                        fn_did = resolved_def_id;
+                                        (nid, resolved_substs, sig)
                                     };
 
-                                    ctxt.trans();
+                                    let mir = &self.mir_map.map[&nid];
+
+                                    fn_sig = monomorphize::apply_param_substs(self.tcx, substs, sig);
+                                    {
+                                        let mut ctxt = BinaryenFnCtxt {
+                                            tcx: self.tcx,
+                                            mir_map: self.mir_map,
+                                            mir: mir,
+                                            did: fn_did,
+                                            sig: &fn_sig,
+                                            module: self.module,
+                                            fun_types: &mut self.fun_types,
+                                            fun_names: &mut self.fun_names,
+                                            c_strings: &mut self.c_strings,
+                                        };
+
+                                        ctxt.trans();
+                                    }
                                 }
                             }
 
@@ -546,6 +717,74 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                 }
             }
             _ => panic!()
+        }
+    }
+
+    fn generate_runtime_start(&mut self, entry_fn: &str) -> BinaryenFunctionRef {
+        // runtime start fn
+        let runtime_start_name = "__wasm_start";
+        let runtime_start_name = CString::new(runtime_start_name).expect("");
+        let runtime_start_name_ptr = runtime_start_name.as_ptr();
+        self.c_strings.push(runtime_start_name);
+
+        let entry_fn_name = &self.fun_names[&(self.did, self.sig.clone())];
+
+        unsafe {
+            let runtime_start_ty = BinaryenAddFunctionType(self.module,
+                                                           runtime_start_name_ptr,
+                                                           BinaryenNone(),
+                                                           ptr::null_mut(),
+                                                           BinaryenIndex(0));
+
+            let mut statements = vec![];
+
+            // set-up memory and stack
+            // FIXME: decide how memory's going to work, the stack pointer address,
+            //        track its initial size, etc and extract that into its own abstraction
+            //     -> temporarily, just ask for one 64K page
+            BinaryenSetMemory(self.module, BinaryenIndex(1), BinaryenIndex(1),
+                              ptr::null(), ptr::null(), ptr::null(), ptr::null(),
+                              BinaryenIndex(0));
+
+            let stack_pointer = BinaryenConst(self.module, BinaryenLiteralInt32(0));
+            let stack_top = BinaryenConst(self.module, BinaryenLiteralInt32(0xFFFF));
+            let stack_init = BinaryenStore(self.module, 4, 0, 0, stack_pointer, stack_top);
+            statements.push(stack_init);
+
+            // call start_fn(0, 0) or main()
+            let entry_fn_call;
+            if entry_fn == "start" {
+                let start_args = [
+                    BinaryenConst(self.module, BinaryenLiteralInt32(0)),
+                    BinaryenConst(self.module, BinaryenLiteralInt32(0))
+                ];
+                entry_fn_call = BinaryenCall(self.module,
+                                             entry_fn_name.as_ptr(),
+                                             start_args.as_ptr(),
+                                             BinaryenIndex(start_args.len() as _),
+                                             BinaryenInt32());
+            } else {
+                assert!(entry_fn == "main");
+                entry_fn_call = BinaryenCall(self.module,
+                                             entry_fn_name.as_ptr(),
+                                             ptr::null(),
+                                             BinaryenIndex(0),
+                                             BinaryenNone());
+            }
+
+            statements.push(entry_fn_call);
+
+            let body = BinaryenBlock(self.module,
+                                     ptr::null(),
+                                     statements.as_ptr(),
+                                     BinaryenIndex(statements.len() as _));
+
+            BinaryenAddFunction(self.module,
+                                runtime_start_name_ptr,
+                                runtime_start_ty,
+                                ptr::null_mut(),
+                                BinaryenIndex(0),
+                                body)
         }
     }
 
@@ -609,4 +848,19 @@ fn sanitize_symbol(s: &str) -> String {
             _ => c
         }
     }).collect()
+}
+
+// The following is imported from miri as well
+trait StructExt {
+    fn field_offset(&self, index: usize) -> Size;
+}
+
+impl StructExt for layout::Struct {
+    fn field_offset(&self, index: usize) -> Size {
+        if index == 0 {
+            Size::from_bytes(0)
+        } else {
+            self.offset_after_field[index - 1]
+        }
+    }
 }


### PR DESCRIPTION
1) Switch back to WebAssembly/binaryen
- now that the cmake PR has been merged upstream, we don't need our forks
- update build.rs to configure binaryen to build as a static lib
- update binding to support new features

2) First foray into the Land of Memory
- added binaryen module validation, thanks to the update to master.
  Prepared and tested using it to: optimize the module, launch the
  interpreter (both need CLI options, but work now, and are just
  commented out). The latter will be useful to integrate with the testing
  infrastructure
- turned off the export attributes for now (even though there’s a good
  chance we’ll need them eventually :)
- refactored `trans_rval` into a more general assignment trans (similar
  to miri, and brought in some of its code again) to allow for lvalue
  knowledge, its type and memory layout (which will for instance be
  useful to emit more than just i32 binary ops)
- this has allowed a prototype implementation of a stack in wasm linear
  memory (1 static 64k page only for now) by emitting our own function prologue and
  epilogue to handle the stack pointer. (This at the very least will need
  to be extracted into its own abstraction, and improved/tested esp.
  regarding alignments, optimized, etc)
- with this, a basic alloca was added to create simple structs (within
  the current existing limitations around types, i.e. i32s only) emitting store/loads for assignments and access; With impl and refs — and an example using it
- added the runtime start fn we talked about in the previous PR, to set
  up some of our data, and call either the `#[start]` entry fn with `(0,
  0)`, or `#[main]` directly. This `__wasm_start` fn will be called
  automatically on module start

r? @brson @eholk
