### PR TITLE
Add a simple testcase that shows we can import modules from other files.

### DIFF
--- a/tests/run-pass/hello-world-tinycore.rs
+++ b/tests/run-pass/hello-world-tinycore.rs
@@ -1,0 +1,30 @@
+#![feature(intrinsics, lang_items, start, no_core, fundamental)]
+#![no_core]
+#![allow(unused_imports)]
+
+pub mod tinycore;
+use tinycore::*;
+
+// access to the wasm "spectest" module test printing functions
+mod wasm {
+    pub fn print_i32(i: isize) {
+        unsafe { _print_i32(i); }
+    }
+
+    extern {
+        fn _print_i32(i: isize);
+    }
+}
+
+fn real_main() -> isize {
+    let i = 1;
+    let j = i + 2;
+    j
+}
+
+#[start]
+fn main(_i: isize, _: *const *const u8) -> isize {
+    let result = real_main() + 3;
+    wasm::print_i32(result); //~ (i32.const 6)
+    result
+}

--- a/tests/run-pass/tinycore/mod.rs
+++ b/tests/run-pass/tinycore/mod.rs
@@ -1,0 +1,35 @@
+//! This is a minimal libcore-like library that can be used by tests
+//! before we support the actual libcore.
+
+#[lang = "sized"]
+#[fundamental]
+pub trait Sized { }
+
+#[lang = "copy"]
+pub trait Copy : Clone { }
+
+pub trait Clone : Sized { }
+
+#[lang = "add"]
+pub trait Add<RHS = Self> {
+    type Output;
+    fn add(self, rhs: RHS) -> Self::Output;
+}
+
+impl Add for isize {
+    type Output = isize;
+    fn add(self, rhs: isize) -> Self::Output { self + rhs }
+}
+
+
+#[link(name = "c")]
+extern { }
+
+//extern { fn puts(s: *const u8); }
+//extern "rust-intrinsic" { fn transmute<T, U>(t: T) -> U; }
+
+#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "eh_unwind_resume"] extern fn eh_unwind_resume() {}
+#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[no_mangle] pub extern fn rust_eh_register_frames () {}
+#[no_mangle] pub extern fn rust_eh_unregister_frames () {}


### PR DESCRIPTION
This will also let us avoid a lot of boilerplate code in subsequent tests.

Issue #29 
