### PR TITLE
Use getopts for command line parsing

### DIFF
--- a/src/bin/mir2wasm.rs
+++ b/src/bin/mir2wasm.rs
@@ -2,6 +2,8 @@
 
 extern crate env_logger;
 extern crate getopts;
+#[macro_use]
+extern crate log;
 extern crate mir2wasm;
 extern crate rustc;
 extern crate rustc_driver;
@@ -10,6 +12,7 @@ extern crate rustc_driver;
 #[link_args = "-lstdc++ -static-libstdc++"]
 extern { }
 
+use getopts::{optflag, getopts};
 use mir2wasm::trans::{self, WasmTransOptions};
 use rustc::session::Session;
 use rustc_driver::{driver, CompilerCalls};
@@ -53,31 +56,51 @@ impl<'a> CompilerCalls<'a> for WasmCompilerCalls {
 fn main() {
     env_logger::init().unwrap();
 
-    let wasm_compiler_args = ["--run", "-O", "-q", "-h", "--help"];
-    let rustc_args : Vec<String> =
-        std::env::args().filter(|arg| !wasm_compiler_args.contains(&arg.as_ref())).collect();
+    let opts = &[
+        optflag("r", "run", "run the compiled module through the interpreter, without printing it"),
+        optflag("q", "", "do not print the compiled wast module"),
+        optflag("O", "", "optimize the compiled wast module"),
+        optflag("h", "help", "display this help message"),
+    ];
 
-    // TODO: use a command line parsing library
-    let mut options = WasmTransOptions::new();
-    for flag in std::env::args().filter(|arg| wasm_compiler_args.contains(&arg.as_ref())) {
-        match flag.as_ref() {
-            "--run" => { options.interpret = true }
-            "-O" => { options.optimize = true }
-            "-q" => { options.print = false }
-            "-h" | "--help" => {
-                let usage = "mir2wasm [OPTIONS] INPUT \n\n\
-                             Options: \n    \
-                             -h, --help    Display this message \n    \
-                             -O            Optimize the compiled wast module \n    \
-                             --run         Run the compiled module through the interpreter, without printing it \n    \
-                             -q            Don't print the compiled wast module";
-                println!("usage: {}", usage);
-                process::exit(0);
+    fn is_wasm_arg(s: &String, opts: &[getopts::OptGroup]) -> bool {
+        for o in opts {
+            if s.starts_with("--") && &s[2..] == &o.long_name {
+                return true;
             }
-            _ => panic!("unexpected compiler flag: {}", flag)
+            if s.starts_with("-") && &s[1..] == &o.short_name {
+                return true;
+            }
         }
-    }
+        return false;
+    };
 
+    let args : Vec<String> = std::env::args().collect();
+    info!("command line: {:?}", args);
+
+    let rustc_args : Vec<String> =
+        std::env::args().filter(|arg| !is_wasm_arg(arg, opts)).collect();
+    let wasm_args : Vec<String> =
+        std::env::args().filter(|arg| is_wasm_arg(arg, opts)).collect();
+
+    let mut options = WasmTransOptions::new();
+
+    let matches = getopts(&wasm_args[..], opts).expect("could not parse command line arguments");
+
+    if matches.opt_present("h") {
+        print!("{}", getopts::usage("Usage: mir2wasm [options]", opts));
+        return;
+    }
+    if matches.opt_present("r") {
+        options.interpret = true;
+    }
+    if matches.opt_present("O") {
+        options.optimize = true;
+    }
+    if matches.opt_present("q") {
+        options.print = false;
+    }
+    
     let mut compiler_calls = WasmCompilerCalls::new(options);
     match rustc_driver::run_compiler(&rustc_args, &mut compiler_calls) {
         (Ok(_), _) => process::exit(0),


### PR DESCRIPTION
This is using the rustc private version of getopts. It'd probably be better to use the Cargo version, but we're probably okay since the ultimate goal is to be another rustc backend.
