### PR TITLE
Generate binaries that run on V8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ tex/*/out
 *.dot
 *.mir
 *~
+/wasm-install
+/.wasm-install-ver
+/.wasm-install.tbz2

--- a/build.rs
+++ b/build.rs
@@ -13,8 +13,8 @@ const WASM_BUILD: &'static str = "9901";
 fn main() {
     let cmake = thread::spawn(|| {
         if !Path::new("binaryen/.git").exists() {
-            let _ = Command::new("git").args(&["submodule", "update", "--init"])
-                .status();
+            Command::new("git").args(&["submodule", "update", "--init"])
+                .status().expect("error updating submodules");
         }
         cmake::Config::new("binaryen")
             .define("BUILD_STATIC_LIB", "ON")
@@ -73,7 +73,7 @@ fn update_wasm_toolchain() {
     let url = url.as_str();
     Command::new("wget").args(&[url, "-O", TMP_FILE]).status()
         .and_then(|_| {
-            Command::new("tar").args(&["xjvf", TMP_FILE]).status()
+            Command::new("tar").args(&["xjf", TMP_FILE]).status()
         })
         .and_then(|_| {
             File::create(WASM_INSTALL_VER)
@@ -81,5 +81,5 @@ fn update_wasm_toolchain() {
         .and_then(|mut file| {
             writeln!(file, "{}", WASM_BUILD)
         })
-        .unwrap();
+        .expect("error downloading wasm toolchain");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,34 @@
 extern crate cmake;
 
-use std::process::Command;
+use std::env;
+use std::fs::File;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::process::Command;
+use std::thread;
+
+/// Build from https://wasm-stat.us that we are known to work with.
+const WASM_BUILD: &'static str = "9901";
 
 fn main() {
-    if !Path::new("binaryen/.git").exists() {
-        let _ = Command::new("git").args(&["submodule", "update", "--init"])
-                        .status();
-    }
-    let dst = cmake::Config::new("binaryen")
-                 .define("BUILD_STATIC_LIB", "ON")
-                 .build();
+    let cmake = thread::spawn(|| {
+        if !Path::new("binaryen/.git").exists() {
+            let _ = Command::new("git").args(&["submodule", "update", "--init"])
+                .status();
+        }
+        cmake::Config::new("binaryen")
+            .define("BUILD_STATIC_LIB", "ON")
+            .build()
+    });
+
+    let toolchain = thread::spawn(|| {
+        if env::var("HOST").unwrap().contains("linux") {
+            update_wasm_toolchain();
+        }
+    });
+
+    let dst = cmake.join().unwrap();
+    let _ = toolchain.join();
 
     println!("cargo:rustc-link-search=native={}/build/lib", dst.display());
     println!("cargo:rustc-link-lib=static=binaryen");
@@ -31,4 +49,37 @@ fn print_deps(path: &Path) {
             println!("cargo:rerun-if-changed={}", e.path().display());
         }
     }
+}
+
+/// Downloads the wasm toolchain from https://wasm-stat.us/ if necessary.
+fn update_wasm_toolchain() {
+    const WASM_INSTALL_VER : &'static str = ".wasm-install-ver";
+
+    // Check if the right version is already in .wasm-install-ver
+    if let Ok(mut file) = File::open(WASM_INSTALL_VER) {
+        let mut contents = String::new();
+        if let Ok(_) = file.read_to_string(&mut contents) {
+            if WASM_BUILD == contents.trim() {
+                return;
+            }
+        }
+    }
+
+    // If we got here, we need to update.
+    const TMP_FILE : &'static str = ".wasm-install.tbz2";
+
+    let url = format!("https://storage.googleapis.com/wasm-llvm/builds/git/wasm-binaries-{}.tbz2",
+                      WASM_BUILD);
+    let url = url.as_str();
+    Command::new("wget").args(&[url, "-O", TMP_FILE]).status()
+        .and_then(|_| {
+            Command::new("tar").args(&["xjvf", TMP_FILE]).status()
+        })
+        .and_then(|_| {
+            File::create(WASM_INSTALL_VER)
+        })
+        .and_then(|mut file| {
+            writeln!(file, "{}", WASM_BUILD)
+        })
+        .unwrap();
 }

--- a/fact.js
+++ b/fact.js
@@ -1,4 +1,4 @@
-let buffer = readbuffer('test.wasm');
+let buffer = readbuffer('fact.wasm');
 
 let empty_function = function() {}
 let module_handler = {

--- a/rust-examples/fact.rs
+++ b/rust-examples/fact.rs
@@ -1,0 +1,13 @@
+#![feature(lang_items, no_core)]
+
+#![no_core]
+#![no_std]
+
+#[no_mangle]
+pub fn fact(_n: i32) -> i32 {
+    120
+}
+
+#[lang = "sized"]
+//#[fundamental]
+trait Sized { }

--- a/src/bin/mir2wasm.rs
+++ b/src/bin/mir2wasm.rs
@@ -2,6 +2,8 @@
 
 extern crate env_logger;
 extern crate getopts;
+#[macro_use]
+extern crate log;
 extern crate mir2wasm;
 extern crate rustc;
 extern crate rustc_driver;
@@ -10,6 +12,7 @@ extern crate rustc_driver;
 #[link_args = "-lstdc++ -static-libstdc++"]
 extern { }
 
+use getopts::{optflag, getopts};
 use mir2wasm::trans::{self, WasmTransOptions};
 use rustc::session::Session;
 use rustc_driver::{driver, CompilerCalls};
@@ -53,31 +56,51 @@ impl<'a> CompilerCalls<'a> for WasmCompilerCalls {
 fn main() {
     env_logger::init().unwrap();
 
-    let wasm_compiler_args = ["--run", "-O", "-q", "-h", "--help"];
-    let rustc_args : Vec<String> =
-        std::env::args().filter(|arg| !wasm_compiler_args.contains(&arg.as_ref())).collect();
+    let opts = &[
+        optflag("r", "run", "run the compiled module through the interpreter, without printing it"),
+        optflag("q", "", "do not print the compiled wast module"),
+        optflag("O", "", "optimize the compiled wast module"),
+        optflag("h", "help", "display this help message"),
+    ];
 
-    // TODO: use a command line parsing library
-    let mut options = WasmTransOptions::new();
-    for flag in std::env::args().filter(|arg| wasm_compiler_args.contains(&arg.as_ref())) {
-        match flag.as_ref() {
-            "--run" => { options.interpret = true }
-            "-O" => { options.optimize = true }
-            "-q" => { options.print = false }
-            "-h" | "--help" => {
-                let usage = "mir2wasm [OPTIONS] INPUT \n\n\
-                             Options: \n    \
-                             -h, --help    Display this message \n    \
-                             -O            Optimize the compiled wast module \n    \
-                             --run         Run the compiled module through the interpreter, without printing it \n    \
-                             -q            Don't print the compiled wast module";
-                println!("usage: {}", usage);
-                process::exit(0);
+    fn is_wasm_arg(s: &String, opts: &[getopts::OptGroup]) -> bool {
+        for o in opts {
+            if s.starts_with("--") && &s[2..] == &o.long_name {
+                return true;
             }
-            _ => panic!("unexpected compiler flag: {}", flag)
+            if s.starts_with("-") && &s[1..] == &o.short_name {
+                return true;
+            }
         }
-    }
+        return false;
+    };
 
+    let args : Vec<String> = std::env::args().collect();
+    info!("command line: {:?}", args);
+
+    let rustc_args : Vec<String> =
+        std::env::args().filter(|arg| !is_wasm_arg(arg, opts)).collect();
+    let wasm_args : Vec<String> =
+        std::env::args().filter(|arg| is_wasm_arg(arg, opts)).collect();
+
+    let mut options = WasmTransOptions::new();
+
+    let matches = getopts(&wasm_args[..], opts).expect("could not parse command line arguments");
+
+    if matches.opt_present("h") {
+        print!("{}", getopts::usage("Usage: mir2wasm [options]", opts));
+        return;
+    }
+    if matches.opt_present("r") {
+        options.interpret = true;
+    }
+    if matches.opt_present("O") {
+        options.optimize = true;
+    }
+    if matches.opt_present("q") {
+        options.print = false;
+    }
+    
     let mut compiler_calls = WasmCompilerCalls::new(options);
     match rustc_driver::run_compiler(&rustc_args, &mut compiler_calls) {
         (Ok(_), _) => process::exit(0),

--- a/src/binaryen.rs
+++ b/src/binaryen.rs
@@ -273,7 +273,7 @@ extern {
 
     pub fn BinaryenModuleWrite(module: BinaryenModuleRef, output: *const c_char, outputSize: size_t) -> size_t;
 
-    pub fn BinaryenModuleRead(input: *const c_char, inputSize: size_t) -> BinaryenModuleRef;
+    pub fn BinaryenModuleRead(input: *mut c_char, inputSize: size_t) -> BinaryenModuleRef;
 
     pub fn BinaryenModuleInterpret(module: BinaryenModuleRef);
 

--- a/src/binaryen.rs
+++ b/src/binaryen.rs
@@ -271,9 +271,9 @@ extern {
 
     pub fn BinaryenModuleOptimize(module: BinaryenModuleRef);
 
-    pub fn BinaryenModuleWrite(module: BinaryenModuleRef, output: *const c_char, outputSize: size_t) -> size_t;
+    pub fn BinaryenModuleWrite(module: BinaryenModuleRef, output: *mut c_char, outputSize: size_t) -> size_t;
 
-    pub fn BinaryenModuleRead(input: *mut c_char, inputSize: size_t) -> BinaryenModuleRef;
+    pub fn BinaryenModuleRead(input: *const c_char, inputSize: size_t) -> BinaryenModuleRef;
 
     pub fn BinaryenModuleInterpret(module: BinaryenModuleRef);
 

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -14,6 +14,11 @@ use rustc::traits::ProjectionMode;
 use syntax::ast::{NodeId, IntTy, UintTy, FloatTy, MetaItemKind, LitKind};
 use syntax::codemap::Span;
 use std::ffi::CString;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::mem;
+use std::path::Path;
 use std::ptr;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -63,6 +68,8 @@ pub fn trans_crate<'a, 'tcx>(tcx: &TyCtxt<'a, 'tcx, 'tcx>,
 
     tcx.map.krate().visit_all_items(v);
 
+    v.write_to_file("test.wasm").expect("error writing wasm file");
+
     unsafe {
         // TODO: check which of the Binaryen optimization passes we want aren't on by default here.
         //       eg, removing unused functions and imports, minification, etc
@@ -99,6 +106,31 @@ struct BinaryenModuleCtxt<'v, 'tcx: 'v> {
     fun_types: HashMap<ty::FnSig<'tcx>, BinaryenFunctionTypeRef>,
     fun_names: HashMap<(DefId, ty::FnSig<'tcx>), CString>,
     c_strings: Vec<CString>,
+}
+
+impl<'v, 'tcx: 'v> BinaryenModuleCtxt<'v, 'tcx> {
+    fn serialize(&self) -> Vec<u8> {
+        unsafe {
+            // TODO: find a way to determine the size of the buffer
+            // first. Right now we just make a giant 4MB buffer and
+            // truncate.
+            let mut buffer = Vec::with_capacity(1 << 22);
+            let size = BinaryenModuleWrite(self.module, mem::transmute(buffer.as_mut_ptr()),
+                                           buffer.capacity());
+
+            buffer.set_len(size);
+            buffer.shrink_to_fit();
+
+            buffer
+        }
+    }
+
+    fn write_to_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let mut file = try!(File::create(path));
+        let buffer = self.serialize();
+
+        file.write_all(buffer.as_slice())
+    }
 }
 
 impl<'v, 'tcx: 'v> Drop for BinaryenModuleCtxt<'v, 'tcx> {

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -121,7 +121,7 @@ impl<'v, 'tcx: 'v> BinaryenModuleCtxt<'v, 'tcx> {
     fn serialize(&self) -> Vec<u8> {
         unsafe {
             // TODO: find a way to determine the size of the buffer
-            // first. Right now we just make a giant 4MB buffer and
+            // first. Right now we just make a 4MB buffer and
             // truncate.
             let mut buffer = Vec::with_capacity(1 << 22);
             let size = BinaryenModuleWrite(self.module, mem::transmute(buffer.as_mut_ptr()),

--- a/test.js
+++ b/test.js
@@ -1,0 +1,17 @@
+let buffer = readbuffer('test.wasm');
+
+let empty_function = function() {}
+let module_handler = {
+  get: function(target, module_name) {
+    return new Proxy({}, {
+      get: function(target, func_name) {
+        return empty_function;
+      }
+    });
+  }
+};
+let proxy_ffi = new Proxy({}, module_handler);
+
+let foo = Wasm.instantiateModule(buffer, proxy_ffi);
+
+print(foo.exports.fact(5));


### PR DESCRIPTION
This change includes two major parts (and also includes #37, but that can be merged separately):
1. Changes to `build.rs` to fetch a build of the Wasm toolchain from https://wasm-stat.us on linux. This also caches the build number and only downloads a new version if its changed.
2. Binary output and exporting Rust functions.

mir2wasm now supports the `-o` option, which gives the name of a .wasm file to write the module to. You can then run this inside of the V8 shell, `d8`. It probably works with other VMs, but I haven't tested that.

This includes `fact.rs` and `fact.js` to demonstrate how this works. You can run this with the following steps, from the repo root:

```
cargo run -- rust-examples/fact.rs -o fact.wasm --crate-type=lib
./wasm-install/bin/d8 --expose_wasm fact.js
```

If all goes well, you should see the number 120 printed out to the console.

This doesn't yet make any attempt to run the test suite under V8, but we have a lot of the ground work in place to do that now.
