### PR TITLE
Run and validate tests under V8

### DIFF
--- a/rt/rustrt.js
+++ b/rt/rustrt.js
@@ -10,7 +10,10 @@ let module_handler = {
     get: function(target, module_name) {
         if(module_name == "spectest") {
             return {
-                print: print
+                print: function(i) {
+                    // TODO: support more data types
+                    print("(i32.const " + i + ")")
+                }
             };
         }
         return new Proxy({}, {

--- a/rt/rustrt.js
+++ b/rt/rustrt.js
@@ -1,0 +1,22 @@
+//! JavaScript runtime for mir2wasm
+
+// This currently assumes it's running under d8, the V8 shell. We'll
+// probably want to make it engine-independent.
+
+let buffer = readbuffer(arguments[0]);
+
+let empty_function = function() {}
+let module_handler = {
+  get: function(target, module_name) {
+    return new Proxy({}, {
+      get: function(target, func_name) {
+        return empty_function;
+      }
+    });
+  }
+};
+let proxy_ffi = new Proxy({}, module_handler);
+
+let foo = Wasm.instantiateModule(buffer, proxy_ffi);
+
+print (foo.exports.foo());

--- a/rt/rustrt.js
+++ b/rt/rustrt.js
@@ -7,16 +7,22 @@ let buffer = readbuffer(arguments[0]);
 
 let empty_function = function() {}
 let module_handler = {
-  get: function(target, module_name) {
-    return new Proxy({}, {
-      get: function(target, func_name) {
-        return empty_function;
-      }
-    });
-  }
+    get: function(target, module_name) {
+        if(module_name == "spectest") {
+            return {
+                print: print
+            };
+        }
+        return new Proxy({}, {
+            get: function(target, func_name) {
+                print("Rust requested runtime function " + module_name + "::" + func_name);
+                return empty_function;
+            }
+        });
+    }
 };
 let proxy_ffi = new Proxy({}, module_handler);
 
 let foo = Wasm.instantiateModule(buffer, proxy_ffi);
 
-print (foo.exports.foo());
+foo.exports.rust_entry();

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -224,10 +224,10 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
         // Translate arg and ret tys to wasm
         let binaryen_args: Vec<_> = self.sig.inputs.iter().map(|t| rust_ty_to_binaryen(t)).collect();
         let mut needs_ret_var = false;
-        let t = self.sig.output;
-        let binaryen_ret = if !t.is_nil() {
+        let ret_ty = self.sig.output;
+        let binaryen_ret = if !ret_ty.is_nil() {
             needs_ret_var = true;
-            rust_ty_to_binaryen(t)
+            rust_ty_to_binaryen(ret_ty)
         } else {
             BinaryenNone()
         };
@@ -307,7 +307,11 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                     }
 
                     debug!("emitting Return from fn {:?}", self.tcx.item_path_str(self.did));
-                    let expr = self.trans_operand(&Operand::Consume(Lvalue::ReturnPointer));
+                    let expr = if ret_ty.is_nil() {
+                        BinaryenExpressionRef(ptr::null_mut())
+                    } else {
+                        self.trans_operand(&Operand::Consume(Lvalue::ReturnPointer))
+                    };
                     let expr = unsafe { BinaryenReturn(self.module, expr) };
                     binaryen_stmts.push(expr);
                 }
@@ -1211,6 +1215,7 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
     fn generate_runtime_start(&mut self, entry_fn: &str) -> BinaryenFunctionRef {
         // runtime start fn
         let runtime_start_name = "__wasm_start";
+        let runtime_export_name = "rust_entry";
         let runtime_start_name = CString::new(runtime_start_name).expect("");
         let runtime_start_name_ptr = runtime_start_name.as_ptr();
         self.c_strings.push(runtime_start_name);
@@ -1266,6 +1271,9 @@ impl<'v, 'tcx: 'v> BinaryenFnCtxt<'v, 'tcx> {
                                      statements.as_ptr(),
                                      BinaryenIndex(statements.len() as _));
 
+            BinaryenAddExport(self.module,
+                              runtime_start_name_ptr,
+                              runtime_export_name.as_ptr() as *const i8);
             BinaryenAddFunction(self.module,
                                 runtime_start_name_ptr,
                                 runtime_start_ty,

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -6,7 +6,6 @@ extern crate log;
 
 use std::fs;
 use std::fs::File;
-use std::io;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{PathBuf, Path};
 use std::str;
@@ -181,8 +180,16 @@ impl<'a> TestSuite<'a> {
         let mir2wasm = &get_target_dir().join("mir2wasm");
 
         let test_out = &get_target_dir().join("tests").join(self.name);
+        if !test_out.parent().unwrap().exists() {
+            fs::create_dir(test_out.parent().unwrap())
+                .expect(format!("could not create test output directory, {}",
+                                test_out.parent().unwrap().display()).as_str());
+        } else {
+            assert!(test_out.parent().unwrap().is_dir());
+        }
         if !test_out.exists() {
-            fs::create_dir(test_out).expect("could not create test output directory");
+            fs::create_dir(test_out).expect(format!("could not create test output directory, {}",
+                                                    test_out.display()).as_str());
         } else {
             assert!(test_out.is_dir());
         }
@@ -261,7 +268,7 @@ fn run_in_vm(wasm: &Path, expected: &[String]) -> bool {
 }
 
 #[cfg(not(target_os="linux"))]
-fn run_in_vm(_wasm: &Path, _expected: &Vec<String>) -> bool {
+fn run_in_vm(_wasm: &Path, _expected: &[String]) -> bool {
     true
 }
 


### PR DESCRIPTION
This change still runs tests using the Binaryen interpreter, but now on Linux it will also run under V8 using binaries downloaded from https://wasm-stat.us/

Obviously this includes changes to `compiletest.rs` to save the intermediate `.wasm` files and then run these through V8.

The other significant addition is `rustrt.js`, which is a place where we can implement support functions in JavaScript that are needed to implement various Rust things. It's not terribly well designed right now, but it's a start.

The way startup works now is that `__wasm_start` gets exported from the Wasm module as `rust_entry`, which is called by V8. With this change, it might actually make sense to bring `__wasm_start` out into the JS code, and just have it call directly into the Rust start function.
