### PR TITLE
Don't translate generic default trait methods.

### DIFF
--- a/rust-examples/operators.rs
+++ b/rust-examples/operators.rs
@@ -131,7 +131,9 @@ fn main() {
     i *= 4;
     i /= 6;
     i -= 1;
-    let j = i == 1;
+
+    let _j = i == 1;
+    // TODO: assert j is true
 
     let result = test(i);
     wasm::print_i32(result); // (i32.const 2)

--- a/rust-examples/struct.rs
+++ b/rust-examples/struct.rs
@@ -36,6 +36,9 @@ pub mod marker {
 
     #[lang = "copy"]
     pub trait Copy : Clone { }
+
+    #[lang = "phantom_data"]
+    pub struct PhantomData<T:?Sized>;
 }
 
 pub mod clone {
@@ -44,6 +47,8 @@ pub mod clone {
     pub trait Clone : Sized {
         fn clone(&self) -> Self;
     }
+
+    pub struct AssertParamIsClone<T: Clone + ?Sized> { _field: ::marker::PhantomData<T> }
 
     // should this #[derive] requirement exist and have to be translated in our case ?
     pub fn assert_receiver_is_clone<T: Clone + ?Sized>(_: &T) {}

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -163,7 +163,7 @@ impl<'v, 'tcx> Visitor<'v> for BinaryenModuleCtxt<'v, 'tcx> {
         let generics = &type_scheme.generics;
 
         // don't translate generic functions yet
-        if generics.has_self || !generics.types.is_empty() {
+        if generics.types.len() + generics.parent_types as usize > 0 {
             return;
         }
 

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -160,9 +160,10 @@ impl<'v, 'tcx> Visitor<'v> for BinaryenModuleCtxt<'v, 'tcx> {
                 b: &'v Block, s: Span, id: NodeId) {
         let did = self.tcx.map.local_def_id(id);
         let type_scheme = self.tcx.lookup_item_type(did);
+        let generics = &type_scheme.generics;
 
         // don't translate generic functions yet
-        if !type_scheme.generics.types.is_empty() {
+        if generics.has_self || !generics.types.is_empty() {
             return;
         }
 

--- a/tests/compile-pass/fibonacci.rs
+++ b/tests/compile-pass/fibonacci.rs
@@ -90,7 +90,7 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
     fn eq(&self, other: &Rhs) -> bool;
 
     #[inline]
-    fn ne(&self, other: &Rhs) -> bool;
+    fn ne(&self, other: &Rhs) -> bool { !self.eq(other) }
 }
 
 impl PartialEq for i32 {

--- a/tests/compile-pass/iterator.rs
+++ b/tests/compile-pass/iterator.rs
@@ -78,7 +78,7 @@ mod cmp {
         fn eq(&self, other: &Rhs) -> bool;
 
         #[inline]
-        fn ne(&self, other: &Rhs) -> bool;
+        fn ne(&self, other: &Rhs) -> bool { !self.eq(other) }
     }
 
     impl PartialEq for i32 {

--- a/tests/compile-pass/operators.rs
+++ b/tests/compile-pass/operators.rs
@@ -100,7 +100,7 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
     fn eq(&self, other: &Rhs) -> bool;
 
     #[inline]
-    fn ne(&self, other: &Rhs) -> bool;
+    fn ne(&self, other: &Rhs) -> bool { !self.eq(other) }
 }
 
 impl PartialEq for isize {

--- a/tests/compile-pass/struct-derive.rs
+++ b/tests/compile-pass/struct-derive.rs
@@ -48,7 +48,7 @@ pub mod clone {
 
     pub struct AssertParamIsClone<T: Clone + ?Sized> { _field: ::marker::PhantomData<T> }
 
-    // should this #[derive] requirement exists and have to be translated in our case ?
+    // should this #[derive] requirement exist and have to be translated in our case ?
     pub fn assert_receiver_is_clone<T: Clone + ?Sized>(_: &T) {}
 
     macro_rules! clone_impl {


### PR DESCRIPTION
I _think_ Self was in the fn's type_scheme.generics.types in the old nightly ?
In any case, this fixes the 3 examples exhibiting the #40 behavior, so I also added the default methods back to the tests that were created from those examples.

(This also fixes the failing struct example.)

There's improvement on the cmp example and test: they are still failing, but not for generics/substs reasons anymore. The PartialOrd::partial_cmp methods generate stores for values of a different type, making the generated wasm module fail binaryen validation.
