### PR TITLE
Run tests in V8 on Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "compiletest_rs 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -63,6 +64,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curl-sys 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dbghelp-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +115,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "gcc"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gdi32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -108,6 +148,16 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libz-sys"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +169,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "metadeps"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
@@ -160,6 +241,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "user32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,19 +276,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "dfcf5bcece56ef953b8ea042509e9dcbdfe97820b7e20d86beb53df30ed94978"
 "checksum compiletest_rs 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0ac936b073036755b7d176f16d4c660f4d6f1390cbe556316af9cb9724117059"
+"checksum curl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "29390ee54dfd5acfcc4b0d2acc96da64060e704324a5fe314799c192fe039f76"
+"checksum curl-sys 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "218a149208e1f4e5f7e20f1d0ed1e9431a086a6b4333ff95dba82237be9c283a"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aba65b63ffcc17ffacd6cf5aa843da7c5a25e3bd4bbe0b7def8b214e411250e5"
 "checksum error-chain 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "369f451d4d6487dff893b48ae01fe02d9b6b4d1694d6f2d331463d49e09c5149"
+"checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 "checksum gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "3da3a2cbaeb01363c8e3704fd9fd0eb2ceb17c6f27abd4c1ef040fb57d20dc79"
+"checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c96061f0c8a2dc27482e394d82e23073569de41d73cd736672ccd3e5c7471bfd"
+"checksum libz-sys 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "905c72a0c260bcd89ddca5afa1c46bebd29b52878a3d58c86865ea42402f88e6"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829fffe7ea1d747e23f64be972991bc516b2f1ac2ae4a3b33d8bea150c410151"
+"checksum openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "756d49c8424483a3df3b5d735112b4da22109ced9a8294f1f5cdf80fb3810919"
+"checksum openssl-sys 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4e38c5a9261a179e63757eee43a1ee63f9033a2e99b8147aa4c245857a995af7"
+"checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)" = "55766c6af610210f970e373f13aa6e01dc895f7ae5884820e71f7ef45c60462d"
 "checksum regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "841591b1e05609a643e3b4d0045fce04f701daba7151ddcd3ad47b080693d5a9"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0694f51610ef7cfac7a1b81de7f1602ee5356e76541bcd62c40e71933338cab1"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3969e500d618a5e974917ddefd0ba152e4bcaae5eb5d9b8c1fbc008e9e28c24e"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ libc = "0.2"
 compiletest_rs = "0.2.3"
 
 [build-dependencies]
+curl = "0.4.2"
 cmake = "0.1.17"

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=support");
     println!("cargo:rustc-link-lib=static=emscripten-optimizer");
     println!("cargo:rustc-link-lib=static=asmjs");
+    println!("cargo:rustc-link-lib=static=wasm");
 
     print_deps(Path::new("binaryen"));
 }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 extern crate cmake;
+extern crate curl;
 
-use std::env;
+use curl::easy::Easy;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -8,13 +9,36 @@ use std::process::Command;
 use std::thread;
 
 /// Build from https://wasm-stat.us that we are known to work with.
-const WASM_BUILD: &'static str = "9901";
+#[cfg(target_os="linux")]
+mod config {
+    pub const DOWLOAD_WASM: bool = true;
+    pub const WASM_BUILD: &'static str = "9901";
+    pub const OS_NAME: &'static str = "linux";
+}
+
+#[cfg(target_os="macos")]
+mod config {
+    pub const DOWLOAD_WASM: bool = true;
+    pub const WASM_BUILD: &'static str = "2345";
+    pub const OS_NAME: &'static str = "mac";
+}
+
+#[cfg(not(any(target_os="linux", target_os="macos")))]
+mod config {
+    pub const DOWLOAD_WASM: bool = false;
+    pub const WASM_BUILD: &'static str = "";
+    pub const OS_NAME: &'static str = "";
+}
+
+use config::WASM_BUILD;
 
 fn main() {
     let cmake = thread::spawn(|| {
         if !Path::new("binaryen/.git").exists() {
-            Command::new("git").args(&["submodule", "update", "--init"])
-                .status().expect("error updating submodules");
+            Command::new("git")
+                .args(&["submodule", "update", "--init"])
+                .status()
+                .expect("error updating submodules");
         }
         cmake::Config::new("binaryen")
             .define("BUILD_STATIC_LIB", "ON")
@@ -22,13 +46,13 @@ fn main() {
     });
 
     let toolchain = thread::spawn(|| {
-        if env::var("HOST").unwrap().contains("linux") {
+        if config::DOWLOAD_WASM {
             update_wasm_toolchain();
         }
     });
 
     let dst = cmake.join().unwrap();
-    let _ = toolchain.join();
+    toolchain.join().expect("Error downloading Wasm toolchain");
 
     println!("cargo:rustc-link-search=native={}/build/lib", dst.display());
     println!("cargo:rustc-link-lib=static=binaryen");
@@ -54,7 +78,7 @@ fn print_deps(path: &Path) {
 
 /// Downloads the wasm toolchain from https://wasm-stat.us/ if necessary.
 fn update_wasm_toolchain() {
-    const WASM_INSTALL_VER : &'static str = ".wasm-install-ver";
+    const WASM_INSTALL_VER: &'static str = ".wasm-install-ver";
 
     // Check if the right version is already in .wasm-install-ver
     if let Ok(mut file) = File::open(WASM_INSTALL_VER) {
@@ -67,20 +91,34 @@ fn update_wasm_toolchain() {
     }
 
     // If we got here, we need to update.
-    const TMP_FILE : &'static str = ".wasm-install.tbz2";
+    const TMP_FILE: &'static str = ".wasm-install.tbz2";
 
-    let url = format!("https://storage.googleapis.com/wasm-llvm/builds/git/wasm-binaries-{}.tbz2",
-                      WASM_BUILD);
+    let url = wasm_url();
     let url = url.as_str();
-    Command::new("wget").args(&[url, "-O", TMP_FILE]).status()
-        .and_then(|_| {
-            Command::new("tar").args(&["xjf", TMP_FILE]).status()
-        })
-        .and_then(|_| {
-            File::create(WASM_INSTALL_VER)
-        })
-        .and_then(|mut file| {
-            writeln!(file, "{}", WASM_BUILD)
-        })
+
+    fetch_url(url, TMP_FILE);
+    Command::new("tar")
+        .args(&["xjf", TMP_FILE])
+        .status()
+        .and_then(|_| File::create(WASM_INSTALL_VER))
+        .and_then(|mut file| writeln!(file, "{}", WASM_BUILD))
         .expect("error downloading wasm toolchain");
+}
+
+fn fetch_url(url: &str, output: &str) {
+    File::create(output).and_then(|mut file| {
+        let mut curl = Easy::new();
+        curl.url(url).expect("Error setting url");
+        curl.write_function(move |data| Ok(file.write(data).expect("Error writing data")))
+            .expect("Error setting write function");
+        curl.perform().expect("Error downloading archive");
+        Ok(())
+    }).expect("Could not open output file");
+}
+
+fn wasm_url() -> String {
+    format!("https://storage.googleapis.com/wasm-llvm/builds/{}/{}/wasm-binaries-{}.tbz2",
+            config::OS_NAME,
+            config::WASM_BUILD,
+            config::WASM_BUILD)
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -279,7 +279,7 @@ impl<'a> TestSuite<'a> {
     }
 }
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="macos"))]
 fn run_in_vm(wasm: &Path, expected: &[String]) -> bool {
     let d8 = Path::new("./wasm-install/bin/d8");
     let rt = Path::new("./rt/rustrt.js");
@@ -293,7 +293,7 @@ fn run_in_vm(wasm: &Path, expected: &[String]) -> bool {
     run_and_check_output("V8", cmd, expected)
 }
 
-#[cfg(not(target_os="linux"))]
+#[cfg(not(any(target_os="linux", target_os="macos")))]
 fn run_in_vm(_wasm: &Path, _expected: &[String]) -> bool {
     true
 }


### PR DESCRIPTION
http://wasm-stat.us is building the Wasm toolchain for Mac now, so this change enables testing on V8 for Mac.

I switched from running `wget` to download the archive to using `libcurl`, since this seems more robust across platforms.

The tests don't actually succeed yet, because we're a bit out of sync between Binaryen and V8, but I'm working on another PR to fix this.