### PR TITLE
Enable parallel building of binaryen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "error-chain 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -181,6 +182,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829fffe7ea1d747e23f64be972991bc516b2f1ac2ae4a3b33d8bea150c410151"
+"checksum num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a225d1e2717567599c24f88e49f00856c6e825a12125181ee42c4257e3688d39"
 "checksum openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "756d49c8424483a3df3b5d735112b4da22109ced9a8294f1f5cdf80fb3810919"
 "checksum openssl-sys 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4e38c5a9261a179e63757eee43a1ee63f9033a2e99b8147aa4c245857a995af7"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ compiletest_rs = "0.2.3"
 [build-dependencies]
 curl = "0.4.2"
 cmake = "0.1.17"
+num_cpus = "1.2.1"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 extern crate cmake;
 extern crate curl;
+extern crate num_cpus;
 
 use curl::easy::Easy;
 use std::fs::File;
@@ -42,6 +43,7 @@ fn main() {
         }
         cmake::Config::new("binaryen")
             .define("BUILD_STATIC_LIB", "ON")
+            .build_arg(format!("-j{}", num_cpus::get() + 2))
             .build()
     });
 
@@ -62,6 +64,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=emscripten-optimizer");
     println!("cargo:rustc-link-lib=static=asmjs");
     println!("cargo:rustc-link-lib=static=wasm");
+    println!("cargo:rustc-link-lib=static=ast");
 
     print_deps(Path::new("binaryen"));
 }


### PR DESCRIPTION
This adds [num_cpus](https://crates.io/crates/num_cpus) as a build dependency and then passes a suitable `-j` option to cmake when building binaryen.